### PR TITLE
A quick fix for `z3-driver.scm`.

### DIFF
--- a/z3-driver.scm
+++ b/z3-driver.scm
@@ -98,6 +98,7 @@
                       (filter (lambda (x) ; ignoring functions
                                 (or (number? (cdr x))
                                     (symbol? (cdr x)) ; for bitvectors
+                                    (boolean? (cdr x)) ; for booleans
                                     )) m))
                     ms)])
       (if (member '() ms) #f  ; if we're skipping a model, let us stop


### PR DESCRIPTION
The following program returns the unexpected result and fails the [test](https://github.com/namin/clpsmt-miniKanren/blob/4fa74fb973c95b7913f0e0239852f18a23073ccc/clpsmt-basic-tests.scm#L11)

```
(run* (q)
    (fresh (v1 v2)
      (z/ `(declare-const ,v1 Bool))
      (z/ `(declare-const ,v2 Bool))
      (== v1 v2)
      (== q v1)))

;; => (#f)
```

This patch fixes the problem, and return `(#f #t)`:
```
(run* (q)
    (fresh (v1 v2)
      (z/ `(declare-const ,v1 Bool))
      (z/ `(declare-const ,v2 Bool))
      (== v1 v2)
      (== q v1)))

;; => (#f #t)
```

Note that 

1. This patch still cannot pass the [test](https://github.com/namin/clpsmt-miniKanren/blob/4fa74fb973c95b7913f0e0239852f18a23073ccc/clpsmt-basic-tests.scm#L11), because that test expects `'(_.0)`. 
   Nevertheless, returning `(#f #t)` is still a correct behavior, consider the following program in cKanren, i.e. CLP(FD):

   ```
   (run* (q)
       (fresh (v1 v2)
              (infd v1 '(0 1))
              (infd v2 '(0 1))
              (== v1 v2)
              (== q v1)))
   ;; => (0 1)
   ```

2. This patch only be used for `z3-driver.scm`.
    `z3-server.scm` currently doesn't support boolean at all, since they don't encode `#t` and `#f` to smtlib format.

PS. I'm using z3-4.8.7.
