### PR TITLE
Fix "no #%datum syntax transformer is bound" bug when run tests in a Racket module

### DIFF
--- a/z3-driver.rkt
+++ b/z3-driver.rkt
@@ -1,6 +1,7 @@
 (define z3-counter-check-sat 0)
 (define z3-counter-get-model 0)
 
+(define ns (make-base-namespace))
 (define read-sat
   (lambda (fn)
     (let ([p (open-input-file fn)])
@@ -40,7 +41,7 @@
                                    ((eq? r 'false) #f)
                                    ((eq? r 'true) #t)
                                    ((and (pair? (cadddr x)) (eq? (cadr (cadddr x)) 'BitVec)) r)
-                                   (else (eval r))))
+                                   (else (eval r ns))))
                                `(lambda ,(map car (caddr x)) ,(cadddr (cdr x))))))
                    (cdr m)))
             (begin

--- a/z3-server.rkt
+++ b/z3-server.rkt
@@ -4,6 +4,8 @@
 
 (provide (all-defined-out))
 
+(define ns (make-base-namespace))
+
 (define z3-counter-check-sat 0)
 (define z3-counter-get-model 0)
 
@@ -67,7 +69,7 @@
                            ((eq? r 'false) #f)
                            ((eq? r 'true) #t)
                            ((and (pair? (cadddr x)) (eq? (cadr (cadddr x)) 'BitVec)) r)
-                           (else (eval r))))
+                           (else (eval r ns))))
                        `(lambda ,(map car (caddr x)) ,(cadddr (cdr x))))))
            (cdr m)))))
 


### PR DESCRIPTION
The current codebase supports Racket, but only in REPL. 

If running in a module, it will crash. 

For example, 

Suppose I'd like some compatible patches (for both Racket and Scheme) via `include`, I may write the following code:

test-check.rkt

```
#lang racket/base
(require racket/include)
(provide test time-test todo)
(include "test-check.scm")
```

clpsmt-basic-tests.rkt

```
#lang racket/base
(require racket/include)
(require "mk.rkt")
(require "test-check.rkt")
(include "clpsmt-basic-tests.scm")
```

Then you can click `clpsmt-basic-tests.rkt` (I use windows) to open DrRacket and Run.

But that will fail, DrRacket complains:

```
?: literal data is not allowed;
 no #%datum syntax transformer is bound in: 0
```

The root cause is that the `read-model` in `z3-driver.rkt` uses `eval` but no namespace passed. It can work well in REPL, but not in a module, see https://docs.racket-lang.org/guide/eval.html#%28part._namespaces%29.

This patch can fix this problem and make the above compatible patches work.

BTW, do you need these Racket compatible patches? i.e. `test-check.rkt`, `clpsmt-basic-tests.rkt`, etc. I can create a new pull-request. (I currently use these Racket compatible patches in my local codebase, because it is convenient to debug in DrRacket).
