### PR TITLE
Add missing provides

### DIFF
--- a/mk.rkt
+++ b/mk.rkt
@@ -17,7 +17,10 @@
          z/
          do-defer-smt-checks!
          get-next-model?
-         toggle-get-next-model?!)
+         toggle-get-next-model?!
+         z3-counter-check-sat
+         z3-counter-get-model
+         )
 
 ;; extra stuff for racket
 ;; due mostly to samth


### PR DESCRIPTION
Fix Racket complaints.

Some tests use these two global variables.

Therefore `mk.rkt` must provide them.